### PR TITLE
feat:add new event, edit past event details,delete past event impleme…

### DIFF
--- a/src/Components/Loader/Loader.module.css
+++ b/src/Components/Loader/Loader.module.css
@@ -6,7 +6,7 @@
   position: absolute;
   background-color: #fffbfa;
   opacity: 0.8;
-  z-index: 900;
+  z-index: 901;
 }
 .loader {
   border: 15px solid white;

--- a/src/pages/Dashboard/components/PersonalDetails/EditEvent.jsx
+++ b/src/pages/Dashboard/components/PersonalDetails/EditEvent.jsx
@@ -4,15 +4,15 @@ import { API_LINK } from "../../../../utils/api"
 import { useState } from "react"
 import { toast } from "react-hot-toast"
 import { useNavigate } from "react-router-dom"
+import Confirmation from "./Modal/Confirmation"
 
 const EditAddEvent = ({ showModal, setShowModal, data, id, index }) => {
   const navigate = useNavigate()
 
   const [eventData, setEventData] = useState(data?.pastEvents[index])
   const [loading, setLoading] = useState(false)
+  const [isConfirmed, setIsConfirmed] = useState(false)
 
-  // console.log(index)
-  // console.log(id)
   const setEventInputs = (value, key) => {
     if (key === "eventPhoto") {
       setEventData((prev) => ({
@@ -43,7 +43,7 @@ const EditAddEvent = ({ showModal, setShowModal, data, id, index }) => {
       // for (let pair of formData.entries()) {
       //   console.log(pair[0], pair[1])
       // }
-      console.log(eventData)
+      // console.log(eventData)
       const token = sessionStorage.getItem("token")
       const updateEventData = await fetch(`${API_LINK}/api/profile/event/edit/${id}`, {
         method: "PATCH",
@@ -56,7 +56,7 @@ const EditAddEvent = ({ showModal, setShowModal, data, id, index }) => {
       })
       // console.log(updateEventData)
       const response = await updateEventData.json()
-      console.log(response)
+      // console.log(response)
       if (!updateEventData.ok || !updateEventData) {
         setLoading(false)
         toast.error(`${response?.message || response?.msg}` || "Something Went Wrong!", {
@@ -99,6 +99,15 @@ const EditAddEvent = ({ showModal, setShowModal, data, id, index }) => {
       ></div>
       <div className='addEventContainer'>
         {loading && <Loader />}
+        {isConfirmed && (
+          <Confirmation
+            message={"Are you sure you want to perform this action?"}
+            yesHandler={editEventDetailUpdateHandler}
+            noHandler={() => {
+              setIsConfirmed(!isConfirmed)
+            }}
+          />
+        )}
         <label className='profile-label'>EDIT PREVIOUS EVENTS*</label>
         <div className='profile-field'>
           <div>
@@ -193,7 +202,8 @@ const EditAddEvent = ({ showModal, setShowModal, data, id, index }) => {
           type='button'
           onClick={() => {
             // setShowModal(!showModal)
-            editEventDetailUpdateHandler()
+            setIsConfirmed(true)
+            // editEventDetailUpdateHandler()
           }}
           className='edit'
           style={{ margin: "1rem auto" }}

--- a/src/pages/Dashboard/components/PersonalDetails/Modal/Confirmation.jsx
+++ b/src/pages/Dashboard/components/PersonalDetails/Modal/Confirmation.jsx
@@ -1,11 +1,18 @@
 import React from "react"
 import styles from "./confirmation.module.css"
-const Confirmation = () => {
+const Confirmation = ({ yesHandler, noHandler, message }) => {
   return (
     <div className={styles.modalBg}>
       <div className={styles.confirmationBox}>
-        <button type='button'>NO</button>
-        <button type='button'>YES</button>
+        <p>{message}</p>
+        <div className={styles.btnContainer}>
+          <button type='button' onClick={noHandler}>
+            NO
+          </button>
+          <button type='button' onClick={yesHandler}>
+            YES
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/src/pages/Dashboard/components/PersonalDetails/Modal/confirmation.module.css
+++ b/src/pages/Dashboard/components/PersonalDetails/Modal/confirmation.module.css
@@ -5,6 +5,29 @@
   place-content: center;
   position: absolute;
   background-color: #fffbfa;
-  opacity: 0.8;
+  opacity: 0.9;
   z-index: 900;
+}
+.confirmationBox {
+  display: grid;
+  place-content: center;
+  gap: 1rem;
+}
+.btnContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 2rem;
+}
+.btnContainer button {
+  width: 6rem;
+  padding: 0.5rem 1rem;
+  border: none;
+  box-shadow: 4px 4px 4px 4px rgba(0, 0, 0, 0.4);
+}
+.btnContainer button:first-child {
+  background-color: red;
+}
+.btnContainer button:last-child {
+  background-color: green;
 }


### PR DESCRIPTION
Welcome to  my Pull Request Pep Talk 😒😁.

`Fixes Breakdown!`
-Speaker can now add new past events on their dashboard
-Speakers can edit past event details
-Speakers can delete from past events.

`Perks`
-Users get to see a dialog box when they want to edit an event and when they want to delete an event.

`Next Fixes`
- Cover picture updateability
- Profile picture updateability
- Past Event Picture Uploadability
Thank you, 
See you next time!